### PR TITLE
Changing Link to encompass entire tile

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -140,22 +140,22 @@ const Header = ({ siteTitle }) => {
         </div>
         <Divider />
         <List>
-          <ListItem button>
-            <ListItemIcon>
-              <HomeIcon />
-            </ListItemIcon>
-            <ListItemText>
-              <Link to="/">Home</Link>
-            </ListItemText>
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <ListIcon />
-            </ListItemIcon>
-            <ListItemText>
-              <Link to="/components">Components</Link>
-            </ListItemText>
-          </ListItem>
+          <Link to="/">
+            <ListItem button>
+              <ListItemIcon>
+                <HomeIcon />
+              </ListItemIcon>
+              <ListItemText>Home</ListItemText>
+            </ListItem>
+          </Link>
+          <Link to="/components">
+            <ListItem button>
+              <ListItemIcon>
+                <ListIcon />
+              </ListItemIcon>
+              <ListItemText>Components</ListItemText>
+            </ListItem>
+          </Link>
         </List>
       </Drawer>
     </div>


### PR DESCRIPTION
Without the change, only when you directly click the text in the header does the page change. I think it's a better experience to be able to change by selecting the entire tile :)